### PR TITLE
read_file behaviour when file is not present

### DIFF
--- a/mpyq.py
+++ b/mpyq.py
@@ -192,6 +192,8 @@ class MPQArchive(object):
                 raise RuntimeError("Unsupported compression type.")
 
         hash_entry = self.get_hash_table_entry(filename)
+        if hash_entry is None:
+            return None
         block_entry = self.block_table[hash_entry.block_table_index]
 
         # Read the block.


### PR DESCRIPTION
read_file would throw an AttributeError when trying to read file not present in hash table, while returning None when file is present but has no EXISTS bit set.
This unifies read_file behaviour to returning None.
