### PR TITLE
Allow decompress (by force)

### DIFF
--- a/mpyq.py
+++ b/mpyq.py
@@ -176,7 +176,7 @@ class MPQArchive(object):
             if (entry.hash_a == hash_a and entry.hash_b == hash_b):
                 return entry
 
-    def read_file(self, filename):
+    def read_file(self, filename, force_decompress=False):
         """Read a file from the MPQ archive."""
 
         def decompress(data):
@@ -229,7 +229,7 @@ class MPQArchive(object):
                 # Single unit files only need to be decompressed, but
                 # compression only happens when at least one byte is gained.
                 if (block_entry.flags & MPQ_FILE_COMPRESS and
-                    block_entry.size > block_entry.archived_size):
+                    (force_decompress or block_entry.size > block_entry.archived_size)):
                     file_data = decompress(file_data)
 
             return file_data


### PR DESCRIPTION
I had a recent [request to accept file objects](https://github.com/GraylinKim/sc2reader/issues/21) which wasn't introduced into mpyq until version 0.1.7. This is an attempt at a clean solution to the issues raised in [Issue#7](https://github.com/arkx/mpyq/issues/7#issuecomment-831664) which will allow sc2reader to float back to the latest version of mpyq instead of anchoring at 0.1.5 (like we currently do) or forking (which we don't want to do).

My idea is to allow decompress by force on read_file for when you "know what you are doing". This will allow us, and anyone else to handle tampered files as discussed in the issue.

Let me know what you think.
