### PR TITLE
Variable header not initialized for invalid file.

### DIFF
--- a/mpyq.py
+++ b/mpyq.py
@@ -139,6 +139,8 @@ class MPQArchive(object):
             header = read_mpq_header(user_data_header['mpq_header_offset'])
             header['offset'] = user_data_header['mpq_header_offset']
             header['user_data_header'] = user_data_header
+        else:
+            raise ValueError("Invalid file header.")
 
         return header
 


### PR DESCRIPTION
If invoking this script for an invalid MPQ file, the header variable
is not initalized and the script fails with the following error:

UnboundLocalError: local variable 'header' referenced before assignment

Better to throw a more specific message.
