### PR TITLE
Properly write empty files to disk.

### DIFF
--- a/mpyq.py
+++ b/mpyq.py
@@ -253,7 +253,7 @@ class MPQArchive(object):
         os.chdir(archive_name)
         for filename, data in self.extract().items():
             f = open(filename, 'wb')
-            f.write(data)
+            f.write(data or "")
             f.close()
 
     def extract_files(self, *filenames):
@@ -261,7 +261,7 @@ class MPQArchive(object):
         for filename in filenames:
             data = self.read_file(filename)
             f = open(filename, 'wb')
-            f.write(data)
+            f.write(data or "")
             f.close()
 
     def print_headers(self):


### PR DESCRIPTION
Sometime the MPQ file listing will include files for which there is no data ([example](ggtracker.com/matches/1786123/replay)). In these cases, `read_file` returns `None` and `extract_to_disk` fails with a type error:

```
Traceback (most recent call last):
  File "/home/graylinkim/projects/sc2reader/env/bin/mpyq", line 8, in <module>
    load_entry_point('mpyq==0.2.0', 'console_scripts', 'mpyq')()
  File "build/bdist.linux-x86_64/egg/mpyq.py", line 402, in main
  File "build/bdist.linux-x86_64/egg/mpyq.py", line 254, in extract_to_disk
TypeError: must be string or buffer, not None
```

We can just substitute an empty string for `None` when writing to disk.
