### PR TITLE
When reporting invalid files, show the invalid magic.

### DIFF
--- a/mpyq.py
+++ b/mpyq.py
@@ -140,7 +140,7 @@ class MPQArchive(object):
             header['offset'] = user_data_header['mpq_header_offset']
             header['user_data_header'] = user_data_header
         else:
-            raise ValueError("Invalid file header.")
+            raise ValueError("Invalid file header {0}.".format(magic))
 
         return header
 


### PR DESCRIPTION
This came up when I was doing python3 support. When you know the file you put in _should_ be valid you want to see what the magic came up as and why it was wrong.
